### PR TITLE
Include equal sign in replacement string

### DIFF
--- a/Classes/GNApplicationController.m
+++ b/Classes/GNApplicationController.m
@@ -191,7 +191,7 @@
         if ([urlComponents count] > 1) {
             // For some reason, Gmail does not interpret the query parameter "subject" correctly, and needs "su" instead.
             additionalParameters = [[NSString stringWithFormat:@"&%@",
-                                     urlComponents[1]] stringByReplacingOccurrencesOfString:@"subject" withString:@"su"];
+                                     urlComponents[1]] stringByReplacingOccurrencesOfString:@"subject=" withString:@"su="];
         }
         NSString *url = [NSString stringWithFormat:@"%@?view=cm&tf=0&fs=1&to=%@%@",
                             [account baseUrl],


### PR DESCRIPTION
To avoid replacing the word "subject" when it's in the subject line, or in one of the cc/bcc addresses. Anyone with an equal sign in their e-mail address should be escaping it anyway :)
